### PR TITLE
Set status item title.

### DIFF
--- a/MacGap/Classes/Commands/StatusItem.h
+++ b/MacGap/Classes/Commands/StatusItem.h
@@ -10,6 +10,7 @@
 @protocol StatusItemExports <JSExport>
 JSExportAs(create, - (void) createItem: (NSDictionary*) props);
 @property (readwrite) JSValue *menu;
+@property (readwrite) NSString *title;
 @end
 
 @interface StatusItem : Command <StatusItemExports>

--- a/MacGap/Classes/Commands/StatusItem.m
+++ b/MacGap/Classes/Commands/StatusItem.m
@@ -12,10 +12,11 @@
 
 @interface StatusItem ()
 @property (strong) JSValue* callback;
+@property (strong) NSNumber* titleFontSize;
 @end
 
 @implementation StatusItem
-@synthesize menu;
+@synthesize menu, title;
 - (id) initWithWindowController:(WindowController *)aWindowController
 {
     self = [super init];
@@ -29,7 +30,8 @@
 
 - (void) createItem: (NSDictionary*) props
 {
-    
+    NSString *aTitle = [props valueForKey:@"title"];
+    NSNumber *titleFontSize = [props valueForKey:@"titleFontSize"];
     NSString *image = [props valueForKey:@"image"];
     NSString *alternateImage = [props valueForKey:@"alternateImage"];
     JSValue * cb = [props valueForKey: @"onClick"];
@@ -40,6 +42,9 @@
     if(cb)
         _callback = cb;
     
+    if(titleFontSize)
+        _titleFontSize = titleFontSize;
+
     if(image)
         imgfileUrl  = [NSURL fileURLWithPath:pathForResource(image)];
     
@@ -47,20 +52,31 @@
         altImgfileUrl  = [NSURL fileURLWithPath:pathForResource(alternateImage)];
     
     _statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-    _statusItem.title = @"";
+    
+    if(aTitle)
+        [self setTitle:aTitle];
+
     _statusItem.image = [[NSImage alloc] initWithContentsOfURL:imgfileUrl];
     _statusItem.alternateImage = [[NSImage alloc] initWithContentsOfURL:altImgfileUrl];
     _statusItem.action = @selector(itemClicked:);
     _statusItem.target = self;
     _statusItem.highlightMode = YES;
-    
-    
 }
+
 - (void) setMenu:(JSValue*)aMenu
 {
     menu = aMenu;
     Menu* theMenu = [aMenu toObject];
     _statusItem.menu = theMenu.menu;
+}
+
+- (void) setTitle:(NSString*)aTitle
+{
+    NSMutableAttributedString *attributedTitle=[[NSMutableAttributedString alloc] initWithString:aTitle];
+    NSInteger _stringLength=[aTitle length];
+    NSFont *font=[NSFont menuBarFontOfSize:[_titleFontSize floatValue]];
+    [attributedTitle addAttribute:NSFontAttributeName value:font range:NSMakeRange(0, _stringLength)];
+    _statusItem.attributedTitle = attributedTitle;
 }
 
 - (void)  itemClicked:(id)sender


### PR DESCRIPTION
This is my very first lines of Objective-C, so please bear with me. What I want to achieve is something like this:

``` js
MacGap.StatusItem.create({title: '00:00', titleSize: 8});
```

``` js
MacGap.StatusItem.title = '00:01';
```

The titleSize property is not implemented, I guess that involves using JSContext which is a bit over my head.

I also played with styling the title with html/css (see https://github.com/thecodepath/ios_guides/wiki/Generating-NSAttributedString-from-HTML) but I decided against it since I couldn't find a good way to use the OS X system font (especially since Mavericks uses ".Lucida Grande UI").
