### PR TITLE
Running Task causes crash

### DIFF
--- a/MacGap/Classes/Commands/Task.h
+++ b/MacGap/Classes/Commands/Task.h
@@ -21,7 +21,6 @@ JSExportAs(create, - (JSValue*) createTask: (NSString*) path withCallback: (JSVa
 @property (readwrite) NSDictionary* environment;
 @property (readwrite) NSString* currentDirectoryPath;
 @property (strong) JSManagedValue* callback;
-@property (strong) JSManagedValue* onError;
 @end
 
 @interface Task : Command <TaskExports>

--- a/MacGap/Classes/Commands/Task.m
+++ b/MacGap/Classes/Commands/Task.m
@@ -83,7 +83,6 @@
             self.arguments = nil;
             self.environment = nil;
             self.callback = nil;
-            self.onError = nil;
             self.outFile = nil;
             self.outputPipe = nil;
             self.pipeOutput = NO;


### PR DESCRIPTION
I am not an expert in Obj-c at all, but tried to track down an exception that was being caused. This was the code I had in index.html to reproduce the issue:

``` html
<!DOCTYPE html>
<html>
<head>
  <title>Hello</title>
</head>
<body>

  <script type="text/javascript" charset="utf-8">
      var myTask = MacGap.Task.create('/usr/bin/say', function() {});
      myTask.arguments = ['hello there'];
      myTask.pipeOutput = true;
      myTask.launch();
  </script>
</body>
</html>
```

This would cause the application to crash with this exception:

```
2014-07-20 20:16:25.101 MG[23204:303] -[Task setOnError:]: unrecognized selector sent to instance 0x6000000bf800
2014-07-20 20:16:25.102 MG[23204:303] An uncaught exception was raised
```

It seems to be setting the onError attribute of the Task to nil that is causing the issue. I made an assumption here that it is not being or will be used, so my PR is to remove the onError attribute.

Please let me know if this seems correct, thanks!
