### PR TITLE
Fix incorrect key for titlebar visibility

### DIFF
--- a/MacGap/Classes/WindowController.m
+++ b/MacGap/Classes/WindowController.m
@@ -167,7 +167,7 @@
     
     NSDictionary* titlebarParams = [params objectForKey:@"titlebar"];
     
-    if(![[titlebarParams objectForKey:@"titlebar"] boolValue]) {
+    if(![[titlebarParams objectForKey:@"visible"] boolValue]) {
         self.window.titleVisibility = NSWindowTitleHidden;
         self.window.titlebarAppearsTransparent = YES;
         self.window.styleMask |= NSFullSizeContentViewWindowMask;


### PR DESCRIPTION
It appears that I made an oversight before opening my previous pull request and there is a big that will always make the titlebar invisible. This will resolve that issue and make it work properly. Sorry about that.