### PR TITLE
Added HTML5 Notifications support

### DIFF
--- a/MG.xcodeproj/project.pbxproj
+++ b/MG.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		22B1CF431937734B00D2C294 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 22B1CF281937734B00D2C294 /* main.m */; };
 		22B1CF441937734B00D2C294 /* MG-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 22B1CF291937734B00D2C294 /* MG-Info.plist */; };
 		22BE36ED193B7F8800D8199F /* Defaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 22BE36EC193B7F8800D8199F /* Defaults.m */; };
+		3EEF80B22089DF8100F569D6 /* NotificationProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EEF80AF2089DF8100F569D6 /* NotificationProvider.m */; };
 		65EAED262018C629006617FE /* DraggableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65EAED252018C629006617FE /* DraggableView.m */; };
 /* End PBXBuildFile section */
 
@@ -107,6 +108,9 @@
 		22B1CF2A1937734B00D2C294 /* MG-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MG-Prefix.pch"; sourceTree = "<group>"; };
 		22BE36EB193B7F8800D8199F /* Defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Defaults.h; sourceTree = "<group>"; };
 		22BE36EC193B7F8800D8199F /* Defaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Defaults.m; sourceTree = "<group>"; };
+		3EEF80AF2089DF8100F569D6 /* NotificationProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationProvider.m; sourceTree = "<group>"; };
+		3EEF80B02089DF8100F569D6 /* NotificationProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationProvider.h; sourceTree = "<group>"; };
+		3EEF80B12089DF8100F569D6 /* WebNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebNotification.h; sourceTree = "<group>"; };
 		65EAED242018C629006617FE /* DraggableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DraggableView.h; sourceTree = "<group>"; };
 		65EAED252018C629006617FE /* DraggableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DraggableView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -193,6 +197,9 @@
 		22B1CEFF1937734B00D2C294 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				3EEF80B02089DF8100F569D6 /* NotificationProvider.h */,
+				3EEF80AF2089DF8100F569D6 /* NotificationProvider.m */,
+				3EEF80B12089DF8100F569D6 /* WebNotification.h */,
 				22B1CF001937734B00D2C294 /* Commands */,
 				22B1CF1C1937734B00D2C294 /* Utils.h */,
 				22B1CF1D1937734B00D2C294 /* Utils.m */,
@@ -349,6 +356,7 @@
 				22B1CF3F1937734B00D2C294 /* WindowController.m in Sources */,
 				22B1CF3D1937734B00D2C294 /* Utils.m in Sources */,
 				22B1CF3E1937734B00D2C294 /* WebViewDelegate.m in Sources */,
+				3EEF80B22089DF8100F569D6 /* NotificationProvider.m in Sources */,
 				22B1CF3A1937734B00D2C294 /* StatusItem.m in Sources */,
 				22B1CF311937734B00D2C294 /* Clipboard.m in Sources */,
 				22B1CF2F1937734B00D2C294 /* NSData+Base64.m in Sources */,

--- a/MacGap/Classes/NotificationProvider.h
+++ b/MacGap/Classes/NotificationProvider.h
@@ -1,0 +1,45 @@
+//
+//  NotificationProvider.h
+//  nimbus
+//
+//  Created by Johan Nordberg on 2012-10-27.
+//  Copyright 2012 FFFF00 Agents AB. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+#import "WebNotification.h"
+
+typedef enum {
+  WebNotificationPermissionAllowed,
+  WebNotificationPermissionNotAllowed,
+  WebNotificationPermissionDenied
+} WebNotificationPermission;
+
+@protocol WebNotificationProvider
+- (void)registerWebView:(WebView *)webView;
+- (void)unregisterWebView:(WebView *)webView;
+- (void)showNotification:(WebNotification *)notification fromWebView:(WebView *)webView;
+- (void)cancelNotification:(WebNotification *)notification;
+- (void)notificationDestroyed:(WebNotification *)notification;
+- (void)clearNotifications:(NSArray *)notificationIDs;
+- (WebNotificationPermission)policyForOrigin:(WebSecurityOrigin *)origin;
+
+- (void)webView:(WebView *)webView didShowNotification:(uint64_t)notificationID;
+- (void)webView:(WebView *)webView didClickNotification:(uint64_t)notificationID;
+- (void)webView:(WebView *)webView didCloseNotifications:(NSArray *)notificationIDs;
+@end
+
+@interface WebView (WebViewNotification)
+- (void)_setNotificationProvider:(id<WebNotificationProvider>)notificationProvider;
+- (id<WebNotificationProvider>)_notificationProvider;
+- (void)_notificationControllerDestroyed;
+
+- (void)_notificationDidShow:(uint64_t)notificationID;
+- (void)_notificationDidClick:(uint64_t)notificationID;
+- (void)_notificationsDidClose:(NSArray *)notificationIDs;
+@end
+
+@interface NotificationProvider : NSObject <WebNotificationProvider, NSUserNotificationCenterDelegate>
+
+@end

--- a/MacGap/Classes/NotificationProvider.m
+++ b/MacGap/Classes/NotificationProvider.m
@@ -1,0 +1,99 @@
+//
+//  NotificationProvider.h
+//  nimbus
+//
+//  Created by Johan Nordberg on 2012-10-27.
+//  Copyright 2012 FFFF00 Agents AB. All rights reserved.
+//
+
+
+#import "NotificationProvider.h"
+
+@interface NotificationProvider () {
+  NSMutableDictionary *_userNotifications;
+  NSMutableDictionary *_webNotifications;
+  NSUserNotificationCenter *_notificationCenter;
+}
+@end
+
+NSString *notificationKey(WebNotification *notification) {
+  return [NSString stringWithFormat:@"%lld", notification.notificationID];
+}
+
+@implementation NotificationProvider
+
+- (id)init {
+  self = [super init];
+  if (self) {
+    _userNotifications = [[NSMutableDictionary alloc] init];
+    _webNotifications = [[NSMutableDictionary alloc] init];
+    _notificationCenter = [NSUserNotificationCenter defaultUserNotificationCenter];
+    _notificationCenter.delegate = self;
+  }
+  return self;
+}
+
+// probably safe to ignore since we only have one webview
+- (void)registerWebView:(WebView *)webView {}
+- (void)unregisterWebView:(WebView *)webView {}
+
+- (void)showNotification:(WebNotification *)webNotification fromWebView:(WebView *)webView {
+  NSString *key = notificationKey(webNotification);
+  NSUserNotification *userNotification = [[NSUserNotification alloc] init];
+
+  userNotification.title = webNotification.title;
+  userNotification.informativeText = webNotification.body;
+  userNotification.userInfo = [NSDictionary dictionaryWithObject:key forKey:@"webNotification"];
+  userNotification.soundName = @"digit";
+
+  [_webNotifications setValue:webNotification forKey:key];
+  [_userNotifications setValue:userNotification forKey:key];
+  [_notificationCenter deliverNotification:userNotification];
+}
+
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didActivateNotification:(NSUserNotification *)notification {
+  NSString *key = [notification.userInfo objectForKey:@"webNotification"];
+  WebNotification *webNotification = [_webNotifications valueForKey:key];
+  [webNotification dispatchClickEvent];
+}
+
+- (void)userNotificationCenter:(NSUserNotificationCenter *)center didDeliverNotification:(NSUserNotification *)notification {
+  NSString *key = [notification.userInfo objectForKey:@"webNotification"];
+  WebNotification *webNotification = [_webNotifications valueForKey:key];
+  [webNotification dispatchShowEvent];
+}
+
+- (WebNotificationPermission)policyForOrigin:(WebSecurityOrigin *)origin {
+  return WebNotificationPermissionAllowed;
+}
+
+- (void)cancelNotification:(WebNotification *)webNotification {
+  NSString *key = notificationKey(webNotification);
+  NSUserNotification *userNotification = [_userNotifications valueForKey:key];
+  
+  [webNotification dispatchCloseEvent];
+
+  if (userNotification) [_notificationCenter removeDeliveredNotification:userNotification];
+
+  [_webNotifications removeObjectForKey:key];
+  [_userNotifications removeObjectForKey:key];
+}
+
+- (void)notificationDestroyed:(WebNotification *)webNotification {
+  // never called?
+  NSString *key = notificationKey(webNotification);
+  [_webNotifications removeObjectForKey:key];
+  [_userNotifications removeObjectForKey:key];
+}
+
+- (void)clearNotifications:(NSArray *)notificationIDs {
+  // never called?
+  [_notificationCenter removeAllDeliveredNotifications];
+}
+
+// why does the provider have reciever methods? was never called in my tests
+- (void)webView:(WebView *)webView didShowNotification:(uint64_t)notificationID {}
+- (void)webView:(WebView *)webView didClickNotification:(uint64_t)notificationID {}
+- (void)webView:(WebView *)webView didCloseNotifications:(NSArray *)notificationIDs {}
+
+@end

--- a/MacGap/Classes/WebNotification.h
+++ b/MacGap/Classes/WebNotification.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2012 Apple Computer, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Computer, Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@class WebNotificationPrivate;
+@class WebSecurityOrigin;
+
+@interface WebNotification : NSObject
+{
+    WebNotificationPrivate *_private;
+}
+
+- (NSString *)title;
+- (NSString *)body;
+- (NSString *)tag;
+- (WebSecurityOrigin *)origin;
+- (uint64_t)notificationID;
+
+- (void)dispatchShowEvent;
+- (void)dispatchCloseEvent;
+- (void)dispatchClickEvent;
+- (void)dispatchErrorEvent;
+
+@end

--- a/MacGap/Classes/WindowController.h
+++ b/MacGap/Classes/WindowController.h
@@ -9,6 +9,7 @@
 #import <Cocoa/Cocoa.h>
 #import <WebKit/WebKit.h>
 #import "MacGap.h"
+#import "NotificationProvider.h"
 
 @class WebViewDelegate;
 
@@ -18,6 +19,7 @@
     IBOutlet NSWindow* window;
     WebViewDelegate* webViewDelegate;
     JSContext* jsContext;
+    NotificationProvider *notificationProvider;
 }
 
 @property (nonatomic, readonly, strong) NSMutableDictionary* pluginObjects;

--- a/MacGap/Classes/WindowController.m
+++ b/MacGap/Classes/WindowController.m
@@ -121,6 +121,9 @@
     [self.webView setShouldCloseWithWindow:NO];
     [self.webView setGroupName:@"MacGap"];
     self.pluginObjects = [[NSMutableDictionary alloc] initWithCapacity:20];
+    
+    notificationProvider = [[NotificationProvider alloc] init];
+    [self.webView _setNotificationProvider:notificationProvider];
 }
 
 - (void) setWindowParams


### PR DESCRIPTION
I have added support for HTML5 Notifications through the `NotificationProvider` class and the `WebNotification` interface.

Examples of usage: In the html page, define this function to ask user permission to receive notifications:

```javascript
var notificationShow = function (notif) {
        if (!Notification) {
            return;
        }
        if (Notification.permission !== "granted") {
            Notification.requestPermission();
        } else {
            var notification = new Notification(notif.title, {
                icon: notif.icon,
                body: notif.body,
            });
            notification.onclick = function () {
                window.open(notif.link);
            };
        }
    }//notifyUser
```

```javascript
var myNotif={
 title: "New message",
 link: "http://localhost/deep_link",
 body: "You have got new messages(5)",
 icon: "http://someicon"
};
notificationShow(myNotif);
```

The code is based on https://github.com/jnordberg/irccloudapp/blob/master/NotificationProvider.m.

**NOTE**. I'm not handling deep linking at this time, so the notification will only put the app in foreground / open the app, but will not link right to the specified page.