### PR TITLE
fixed compiler warning about block declarations with no arguments

### DIFF
--- a/MacGap/Classes/Commands/Defaults.m
+++ b/MacGap/Classes/Commands/Defaults.m
@@ -11,8 +11,8 @@
 #import "Event.h"
 #import "JSON.h"
 
-typedef id (^ReturnType)();
-typedef void (^SetType)();
+typedef id (^ReturnType)(void);
+typedef void (^SetType)(void);
 
 @interface Defaults ()
 - (NSString*) addPrefix:(NSString*)key;


### PR DESCRIPTION
On some versions of xcode/clang CLANG_WARN_STRICT_PROTOTYPES defaults to YES which results in warnings for all function prototypes and block declarations with empty params.

If '(void)' is annoying to you stylistically (it is to me a little), I'm more than happy to set CLANG_WARN_STRICT_PROTOTYPES to NO in the target settings instead. Just let me know.